### PR TITLE
Add rust dependency repos as submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,12 @@
+[submodule "rust/st7735-lcd-batch-rs"]
+	path = rust/st7735-lcd-batch-rs
+	url = https://github.com/lupyuen/st7735-lcd-batch-rs
+[submodule "rust/druid-embedded"]
+	path = rust/druid-embedded
+	url = https://github.com/lupyuen/druid-embedded
+[submodule "rust/piet-embedded"]
+	path = rust/piet-embedded
+	url = https://github.com/lupyuen/piet-embedded
+[submodule "rust/kurbo-embedded"]
+	path = rust/kurbo-embedded
+	url = https://github.com/lupyuen/kurbo-embedded

--- a/rust/README.md
+++ b/rust/README.md
@@ -3,11 +3,7 @@
 Rust application, macros and wrappers for Mynewt. To download additional repos needed for the build:
 
 ```bash
-cd rust
-git clone https://github.com/lupyuen/st7735-lcd-batch-rs
-git clone https://github.com/lupyuen/druid-embedded
-git clone https://github.com/lupyuen/piet-embedded
-git clone https://github.com/lupyuen/kurbo-embedded
+git submodule update --init
 ```
 
 ## Contents


### PR DESCRIPTION
This allows users to clone the dependencies automatically:

```
git clone --recurse-submodules https://github.com/lupyuen/pinetime-rust-mynewt
```

or they can be installed later with:

`git submodule update --init`