### PR TITLE
Fixed go install target for 64 bit versions

### DIFF
--- a/scripts/install-pi.sh
+++ b/scripts/install-pi.sh
@@ -63,7 +63,11 @@ cp $HOME/openocd-spi/src/openocd $HOME/pinetime-rust-mynewt/openocd/bin/openocd
 set +x; echo; echo "----- Installing go..."; set -x 
 golangpath=/usr/lib/go-1.13.6/bin
 if [ ! -e $golangpath/go ]; then
-    wget https://dl.google.com/go/go1.13.6.linux-armv6l.tar.gz
+    if [[ $(uname -m) == aarch64 ]];then
+        wget https://dl.google.com/go/go1.13.6.linux-arm64.tar.gz
+    else
+        wget https://dl.google.com/go/go1.13.6.linux-armv6l.tar.gz
+    fi
     tar xf go*.tar.gz
     sudo mv go /usr/lib/go-1.13.6
     rm go*.tar.gz


### PR DESCRIPTION
The new raspberry pi 4b 8gb version has an optional 64 bit OS.