### PR TITLE
Fix Build 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
 
     - name: Install Embedded Arm Toolchain arm-none-eabi-gcc
       if:   steps.cache-toolchain.outputs.cache-hit != 'true'  # Install toolchain if not found in cache
-      uses: fiam/arm-none-eabi-gcc@v1.0.2
+      uses: fiam/arm-none-eabi-gcc@162d71c10065d706b8a07a2f27d7628cad82e4e3
       with:
         # GNU Embedded Toolchain for Arm release name, in the V-YYYY-qZ format (e.g. "9-2019-q4")
         release: 9-2020-q2

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 #
 -->
 
-# PineTime Smart Watch Firmware with Apache Mynewt and Embedded Rust
+# PineTime Smart Watch Firmware with Apache Mynewt and Embedded Rust!
 
 ![PineTime Smart Watch with Apache Mynewt and Embedded Rust](https://lupyuen.github.io/images/pinetime-title.jpg)
 


### PR DESCRIPTION
Pinto exact working commit  instead of version this commit is working and is up to date, 1.0.2 is broken

https://github.com/fiam/arm-none-eabi-gcc/commit/162d71c10065d706b8a07a2f27d7628cad82e4e3